### PR TITLE
add timeout option

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -26,6 +26,7 @@ TOKEN=$(eval_env_variable "${BUILDKITE_PLUGIN_GOKAKASHI_TOKEN:-}")
 CF_CLIENT_ID=$(eval_env_variable "${BUILDKITE_PLUGIN_GOKAKASHI_CF_CLIENT_ID:-}")
 CF_CLIENT_SECRET=$(eval_env_variable "${BUILDKITE_PLUGIN_GOKAKASHI_CF_CLIENT_SECRET:-}")
 SCAN_ID=$(eval_env_variable "${BUILDKITE_PLUGIN_GOKAKASHI_SCAN_ID:-}")
+TIMEOUT=$(eval_env_variable "${BUILDKITE_PLUGIN_GOKAKASHI_TIMEOUT:-}")
 INTERVAL="${BUILDKITE_PLUGIN_GOKAKASHI_INTERVAL:-10}"
 RETRIES="${BUILDKITE_PLUGIN_GOKAKASHI_RETRIES:-10}"
 GOKAKASHI_VERSION="${BUILDKITE_PLUGIN_GOKAKASHI_GOKAKASHI_VERSION:-latest}"
@@ -104,7 +105,16 @@ echo "Trivy version:"
 # Trigger scan if no scan ID is provided
 if [[ -z "$SCAN_ID" ]]; then
   echo "Triggering scan for image: $IMAGE with policy: $POLICY"
-  SCAN_OUTPUT=$(./gokakashi scan image --image="$IMAGE" --policy="$POLICY" --server="$SERVER" --token="$TOKEN" --labels="$LABELS" 2>&1)
+  # Build command with required arguments
+  SCAN_CMD="./gokakashi scan image --image=\"$IMAGE\" --policy=\"$POLICY\" --server=\"$SERVER\" --token=\"$TOKEN\" --labels=\"$LABELS\""
+  
+  # Add timeout if provided
+  if [[ -n "$TIMEOUT" ]]; then
+    SCAN_CMD+=" --timeout=\"$TIMEOUT\""
+  fi
+  
+  # Execute the command
+  SCAN_OUTPUT=$(eval "$SCAN_CMD" 2>&1)
   echo "Scan output: $SCAN_OUTPUT"
   
   # Extract scan ID from output


### PR DESCRIPTION
This PR adds the timeout option in the plugin. Timeout is supported in Gokakashi version 0.3.0 and above.

```
docker run -e BUILDKITE_PLUGIN_GOKAKASHI_SERVER="https://[REDACTED-SERVER-URL]" \
  -e BUILDKITE_PLUGIN_GOKAKASHI_TOKEN="[REDACTED-TOKEN]" \
  -e BUILDKITE_PLUGIN_GOKAKASHI_IMAGE="hello-world:latest" \
  -e BUILDKITE_PLUGIN_GOKAKASHI_POLICY="ci-platform" \
  -e BUILDKITE_PLUGIN_GOKAKASHI_LABELS="agent=test" \
  -e BUILDKITE_PLUGIN_GOKAKASHI_CF_CLIENT_ID="[REDACTED-CF-CLIENT-ID]" \
  -e BUILDKITE_PLUGIN_GOKAKASHI_CF_CLIENT_SECRET="[REDACTED-CF-CLIENT-SECRET]" \
  -e BUILDKITE_PLUGIN_GOKAKASHI_TIMEOUT="300m" \
  --entrypoint /bin/bash \
  gokakashi-plugin \
  /buildkite-plugin/hooks/command

Cloudflare Access credentials configured
Pulling gokakashi binary version: latest
Installing Trivy...
aquasecurity/trivy info checking GitHub for tag 'v0.58.1'
aquasecurity/trivy info found version: 0.58.1 for v0.58.1/Linux/64bit
aquasecurity/trivy info installed /tmp/tmp.ZGjXcQ2zDr/trivy
Trivy version:
Version: 0.58.1
Triggering scan for image: hello-world:latest with policy: ci-platform
Scan output: 2025/06/19 10:30:23 Scan triggered successfully! Scan ID: [REDACTED-SCAN-ID], status: scan_pending
Extracted Scan ID: [REDACTED-SCAN-ID]
Starting gokakashi agent...
2025/06/19 10:30:23 Agent registered successfully! Agent ID: [REDACTED-AGENT-ID], Name: agent-cf4373, Workspace: /tmp/agent-cf4373
2025/06/19 10:30:24 Heartbeat successfully sent for agent ID [REDACTED-AGENT-ID]
2025/06/19 10:30:24 Ephemeral agent registered. Starting in sometime...
2025/06/19 10:31:12 Heartbeat successfully sent for agent ID [REDACTED-AGENT-ID]
2025/06/19 10:31:12 Ephemeral agent [REDACTED-AGENT-ID] waiting for tasks...
2025/06/19 10:31:12 Heartbeat successfully sent for agent ID [REDACTED-AGENT-ID]
2025/06/19 10:31:13 Heartbeat successfully sent for agent ID [REDACTED-AGENT-ID]
2025/06/19 10:31:14 [INFO] Scanning Docker image: hello-world:latest with Trivy (no severity filter)
2025/06/19 10:31:14 [INFO] Setting Trivy timeout to: 300m
2025/06/19 10:31:22 [INFO] Trivy scan completed for image: hello-world:latest. Report saved to: /tmp/trivy-report-646057579.json
2025/06/19 10:31:23 AgentTaskID completed successfully: [REDACTED-TASK-ID]
2025/06/19 10:31:24 Ephemeral agent [REDACTED-AGENT-ID] completed its task and will now exit.
2025/06/19 10:31:24 Agent successfully deregistered. ID: [REDACTED-AGENT-ID], Status: deleted
2025/06/19 10:31:24 Ephemeral agent [REDACTED-AGENT-ID] shutting down.
Scan details available at: https://[REDACTED-SERVER-URL]/api/v1/scans/[REDACTED-SCAN-ID]
Checking scan status (Attempt 1/10)...
Running status command...
Status command exit code: 0
Full status output: 2025/06/19 10:31:25 Scan status: notify_pending
Scan completed successfully with status: notify_pending
Missing agent-access-token. See: `buildkite-agent meta-data set --help`
Report URL: https://[REDACTED-SERVER-URL]/api/v1/scans/[REDACTED-SCAN-ID]
```